### PR TITLE
TextField/PasswordField - Right button overlaps with text and some style and UX changes to Right Button

### DIFF
--- a/FXSkins/src/main/java/com/pixelduke/control/skin/FXTextFieldSkin.java
+++ b/FXSkins/src/main/java/com/pixelduke/control/skin/FXTextFieldSkin.java
@@ -36,9 +36,9 @@ public class FXTextFieldSkin extends TextFieldWithButtonSkin {
         });
     }
 
-    protected void onRightButtonPressed()
+    @Override
+    protected void onRightButtonReleased()
     {
         getSkinnable().setText("");
     }
-
 }

--- a/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
+++ b/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
@@ -203,7 +203,7 @@ public class TextFieldWithButtonSkin extends TextFieldSkin{
         final double clearButtonWidth = rightButton.snappedLeftInset() + rightButton.snappedRightInset();
 
         rightButton.resize(clearButtonWidth, textField.getHeight());
-        positionInArea(rightButton, textField.getWidth() - clearButtonWidth, 0, clearButtonWidth, textField.getHeight(), 0, HPos.LEFT, VPos.TOP);
+        rightButton.setLayoutX(textField.getWidth() - clearButtonWidth);
     }
 
     @Override

--- a/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
+++ b/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
@@ -202,8 +202,8 @@ public class TextFieldWithButtonSkin extends TextFieldSkin{
 
         final double clearButtonWidth = rightButton.snappedLeftInset() + rightButton.snappedRightInset();
 
-        rightButton.resize(clearButtonWidth, textField.getHeight());
-        rightButton.setLayoutX(textField.getWidth() - clearButtonWidth);
+        rightButton.resize(clearButtonWidth, h + textField.snappedTopInset() + textField.snappedBottomInset());
+        rightButton.setLayoutX(w + textField.snappedRightInset() + textField.snappedLeftInset() - clearButtonWidth);
     }
 
     @Override

--- a/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
+++ b/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
@@ -205,7 +205,7 @@ public class TextFieldWithButtonSkin extends TextFieldSkin{
 
         rightButton.resize(clearButtonWidth, h);
         positionInArea(rightButton,
-                (x+w) - clearButtonWidth, y,
+                (x+w) + textField.snappedLeftInset() + textField.snappedRightInset() - (h + textField.snappedTopInset() + textField.snappedBottomInset()), y,
                 clearButtonWidth, h, 0, HPos.CENTER, VPos.CENTER);
     }
 

--- a/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
+++ b/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
@@ -18,6 +18,10 @@
 
 package impl.com.pixelduke.control.skin;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.css.CssMetaData;
@@ -25,17 +29,11 @@ import javafx.css.SimpleStyleableBooleanProperty;
 import javafx.css.Styleable;
 import javafx.css.StyleableProperty;
 import javafx.css.converter.BooleanConverter;
-import javafx.geometry.HPos;
-import javafx.geometry.VPos;
 import javafx.scene.control.SkinBase;
 import javafx.scene.control.TextField;
 import javafx.scene.control.skin.TextFieldSkin;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class TextFieldWithButtonSkin extends TextFieldSkin{
     private static final String RIGHT_BUTTON_VISIBLE_PROPERTY_NAME = "-right-button-visible";

--- a/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
+++ b/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
@@ -198,8 +198,8 @@ public class TextFieldWithButtonSkin extends TextFieldSkin{
     protected void layoutChildren(double x, double y, double w, double h) {
         super.layoutChildren(x, y, w, h);
 
-        final double rightButtonWidth = rightButton.prefWidth(-1);
         final double rightButtonHeight = h + textField.snappedTopInset() + textField.snappedBottomInset();
+        final double rightButtonWidth = rightButton.prefWidth(rightButtonHeight);
 
         rightButton.resize(rightButtonWidth, rightButtonHeight);
         rightButton.setLayoutX(w + textField.snappedRightInset() + textField.snappedLeftInset() - rightButtonWidth);

--- a/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
+++ b/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
@@ -200,13 +200,10 @@ public class TextFieldWithButtonSkin extends TextFieldSkin{
     protected void layoutChildren(double x, double y, double w, double h) {
         super.layoutChildren(x, y, w, h);
 
-        final double clearGraphicWidth = snapSizeX(rightButtonGraphic.prefWidth(-1));
-        final double clearButtonWidth = rightButton.snappedLeftInset() + clearGraphicWidth + rightButton.snappedRightInset();
+        final double clearButtonWidth = rightButton.snappedLeftInset() + rightButton.snappedRightInset();
 
-        rightButton.resize(clearButtonWidth, h);
-        positionInArea(rightButton,
-                (x+w) + textField.snappedLeftInset() + textField.snappedRightInset() - (h + textField.snappedTopInset() + textField.snappedBottomInset()), y,
-                clearButtonWidth, h, 0, HPos.CENTER, VPos.CENTER);
+        rightButton.resize(clearButtonWidth, textField.getHeight());
+        positionInArea(rightButton, textField.getWidth() - clearButtonWidth, 0, clearButtonWidth, textField.getHeight(), 0, HPos.LEFT, VPos.TOP);
     }
 
     @Override

--- a/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
+++ b/FXSkins/src/main/java/impl/com/pixelduke/control/skin/TextFieldWithButtonSkin.java
@@ -200,10 +200,11 @@ public class TextFieldWithButtonSkin extends TextFieldSkin{
     protected void layoutChildren(double x, double y, double w, double h) {
         super.layoutChildren(x, y, w, h);
 
-        final double clearButtonWidth = rightButton.snappedLeftInset() + rightButton.snappedRightInset();
+        final double rightButtonWidth = rightButton.prefWidth(-1);
+        final double rightButtonHeight = h + textField.snappedTopInset() + textField.snappedBottomInset();
 
-        rightButton.resize(clearButtonWidth, h + textField.snappedTopInset() + textField.snappedBottomInset());
-        rightButton.setLayoutX(w + textField.snappedRightInset() + textField.snappedLeftInset() - clearButtonWidth);
+        rightButton.resize(rightButtonWidth, rightButtonHeight);
+        rightButton.setLayoutX(w + textField.snappedRightInset() + textField.snappedLeftInset() - rightButtonWidth);
     }
 
     @Override

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -63,7 +63,6 @@ TextField > .right-button > .right-button-graphic {
 TextField > .right-button {
     -fx-cursor: default;
 
-    -fx-background-color: transparent;
     -fx-background-insets: -0.3333333em -0.6666666em -0.3333333em -0.5833333em; /* 4 8 4 7 px in em */
     -fx-background-radius: 0 3 3 0, 2, 2;
 }
@@ -95,7 +94,6 @@ TextField > .right-button:pressed > .right-button-graphic {
 .password-field > .right-button {
     -fx-cursor: default;
 
-    -fx-background-color: transparent;
     -fx-background-insets: -0.3333333em -0.6666666em -0.3333333em -0.5833333em; /* 4 8 4 7 px in em */
     -fx-background-radius: 0 3 3 0, 2, 2;
 }

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -43,6 +43,10 @@
  *                                                                             *
  ******************************************************************************/
 
+/* Issue #149 (JMetro): Need to use TextField because ColorPicker has custom textfields with "text-field" styleclass that aren't actually of type
+   TextField which will cause an IllegalArgumentException when creating the impl.jfxtras.styles.jmetro.TextFieldSkin object and passing it,
+   for instance, the WebColorField */
+
 TextField {
     -fx-skin: "com.pixelduke.control.skin.FXTextFieldSkin";
 }

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -54,6 +54,10 @@ TextField {
 TextField {
     -right-button-visible: true;
 
+    -fx-padding: 0.3333333em 0.5833333em 0.3333333em 0.5833333em;
+}
+
+TextField:focused {
     -fx-padding: 0.3333333em 3em 0.3333333em 0.5833333em;
 }
 

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -75,8 +75,8 @@ TextField > .right-button:hover > .right-button-graphic {
 TextField > .right-button {
     -fx-cursor: default;
 
-    -fx-background-insets: -0.3333333em -0.6666666em -0.3333333em -0.5833333em; /* 4 8 4 7 px in em */
     -fx-background-radius: 0 3 3 0, 2, 2;
+    -fx-padding: 0 1.0833333em 0 1.0833333em
 }
 
 TextField > .right-button:pressed {
@@ -114,14 +114,13 @@ TextField > .right-button:pressed > .right-button-graphic {
 .password-field > .right-button {
     -fx-cursor: default;
 
-    -fx-background-insets: -0.3333333em -0.6666666em -0.3333333em -0.5833333em; /* 4 8 4 7 px in em */
     -fx-background-radius: 0 3 3 0, 2, 2;
+    -fx-padding: 0 1.0833333em 0 1.0833333em
 }
 
 .password-field > .right-button > .right-button-graphic {
     -fx-shape: "M307.688,399.564c0,1.484-1.203,2.688-2.688,2.688c-1.484,0-2.688-1.203-2.688-2.688s1.203-2.688,2.688-2.688C306.484,396.876,307.688,398.08,307.688,399.564z M297.5,399h2.5c0,0,1.063-4,5-4c3.688,0,5,4,5,4h2.5c0,0-2.063-6.5-7.5-6.5C299,392.5,297.5,399,297.5,399z";
     -fx-scale-shape: false;
-    -fx-padding: 0.416667em;
     -fx-background-color: #111;
 }
 

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -47,23 +47,31 @@ TextField {
     -fx-skin: "com.pixelduke.control.skin.FXTextFieldSkin";
 }
 
-TextField {
-    -right-button-visible: true;
+.text-field {
+    -fx-padding: 0.3333333em 3em 0.3333333em 0.5833333em;
 }
 
-TextField > .right-button > .right-button-graphic {
+.text-field > .right-button > .right-button-graphic {
     -fx-shape: "M221.738,305.873l6.135,6.16l-2.875,2.863l-6.135-6.159l-6.263,6.237l-2.864-2.875l6.263-6.238l-6.177-6.202l2.875-2.863l6.177,6.201l6.244-6.22l2.864,2.876L221.738,305.873z";
 
     -fx-padding: 0.416667em;
-    -fx-background-color: #333;
+    -fx-background-color: #111;
 }
 
-TextField > .right-button:hover {
+.text-field > .right-button {
     -fx-cursor: default;
+
+    -fx-background-color: transparent;
+    -fx-background-insets: -0.3333333em -0.6666666em -0.3333333em -0.5833333em; /* 4 8 4 7 px in em */
+    -fx-background-radius: 0 3 3 0, 2, 2;
 }
 
-TextField > .right-button:hover > .right-button-graphic {
-    -fx-background-color: #666666;
+.text-field > .right-button:pressed {
+    -fx-background-color: -fx-accent;
+}
+
+.text-field > .right-button:pressed > .right-button-graphic {
+    -fx-background-color: white;
 }
 
 /*******************************************************************************
@@ -79,35 +87,10 @@ TextField > .right-button:hover > .right-button-graphic {
 .password-field {
     -right-button-visible: true;
 }
-.password-field > .right-button {
-    -fx-padding: 0.166667em 0.083333em 0.166667em 0.166667em;
-}
 
 .password-field > .right-button > .right-button-graphic {
     -fx-shape: "M307.688,399.564c0,1.484-1.203,2.688-2.688,2.688c-1.484,0-2.688-1.203-2.688-2.688s1.203-2.688,2.688-2.688C306.484,396.876,307.688,398.08,307.688,399.564z M297.5,399h2.5c0,0,1.063-4,5-4c3.688,0,5,4,5,4h2.5c0,0-2.063-6.5-7.5-6.5C299,392.5,297.5,399,297.5,399z";
-    /*-fx-shape: "M1,9c0,0,4-8,11-8s11,8,11,8s-4,8-11,8S1,9,1,9z M12,6c1.7,0,3,1.3,3,3s-1.3,3-3,3s-3-1.3-3-3S10.3,6,12,6z";*/
-
-    -fx-scale-shape: true;
-    -fx-pref-width: 14px;
-    -fx-pref-height: 10px;
-
-    -fx-background-color: #111;
-
-    /*
-    -fx-border-color: #111;
-    -fx-border-width: 1px;
-    */
-}
-
-.password-field > .right-button:hover {
-    -fx-cursor: default;
-}
-
-.password-field > .right-button:hover > .right-button-graphic {
-    -fx-background-color: #777;
-}
-
-.password-field > .right-button:pressed > .right-button-graphic {
+    -fx-scale-shape: false;
     -fx-background-color: #111;
 }
 

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -47,18 +47,20 @@ TextField {
     -fx-skin: "com.pixelduke.control.skin.FXTextFieldSkin";
 }
 
-.text-field {
+TextField {
+    -right-button-visible: true;
+
     -fx-padding: 0.3333333em 3em 0.3333333em 0.5833333em;
 }
 
-.text-field > .right-button > .right-button-graphic {
+TextField > .right-button > .right-button-graphic {
     -fx-shape: "M221.738,305.873l6.135,6.16l-2.875,2.863l-6.135-6.159l-6.263,6.237l-2.864-2.875l6.263-6.238l-6.177-6.202l2.875-2.863l6.177,6.201l6.244-6.22l2.864,2.876L221.738,305.873z";
 
     -fx-padding: 0.416667em;
     -fx-background-color: #111;
 }
 
-.text-field > .right-button {
+TextField > .right-button {
     -fx-cursor: default;
 
     -fx-background-color: transparent;
@@ -66,11 +68,11 @@ TextField {
     -fx-background-radius: 0 3 3 0, 2, 2;
 }
 
-.text-field > .right-button:pressed {
+TextField > .right-button:pressed {
     -fx-background-color: -fx-accent;
 }
 
-.text-field > .right-button:pressed > .right-button-graphic {
+TextField > .right-button:pressed > .right-button-graphic {
     -fx-background-color: white;
 }
 
@@ -86,12 +88,31 @@ TextField {
 
 .password-field {
     -right-button-visible: true;
+
+    -fx-padding: 0.3333333em 3em 0.3333333em 0.5833333em;
+}
+
+.password-field > .right-button {
+    -fx-cursor: default;
+
+    -fx-background-color: transparent;
+    -fx-background-insets: -0.3333333em -0.6666666em -0.3333333em -0.5833333em; /* 4 8 4 7 px in em */
+    -fx-background-radius: 0 3 3 0, 2, 2;
 }
 
 .password-field > .right-button > .right-button-graphic {
     -fx-shape: "M307.688,399.564c0,1.484-1.203,2.688-2.688,2.688c-1.484,0-2.688-1.203-2.688-2.688s1.203-2.688,2.688-2.688C306.484,396.876,307.688,398.08,307.688,399.564z M297.5,399h2.5c0,0,1.063-4,5-4c3.688,0,5,4,5,4h2.5c0,0-2.063-6.5-7.5-6.5C299,392.5,297.5,399,297.5,399z";
     -fx-scale-shape: false;
+    -fx-padding: 0.416667em;
     -fx-background-color: #111;
+}
+
+.password-field > .right-button:pressed {
+    -fx-background-color: -fx-accent;
+}
+
+.password-field > .right-button:pressed > .right-button-graphic {
+    -fx-background-color: white;
 }
 
 /*******************************************************************************

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -64,12 +64,8 @@ TextField:focused {
 TextField > .right-button > .right-button-graphic {
     -fx-shape: "M221.738,305.873l6.135,6.16l-2.875,2.863l-6.135-6.159l-6.263,6.237l-2.864-2.875l6.263-6.238l-6.177-6.202l2.875-2.863l6.177,6.201l6.244-6.22l2.864,2.876L221.738,305.873z";
 
-    -fx-padding: 1em;
-    -fx-scale-shape: false;
+    -fx-padding: 0.416667em;
     -fx-background-color: #111;
-    -fx-scale-x: 0.65;
-    -fx-scale-y: 0.65;
-    -fx-scale-z: 0.65;
 }
 
 TextField > .right-button:hover > .right-button-graphic {
@@ -80,6 +76,7 @@ TextField > .right-button {
     -fx-cursor: default;
 
     -fx-background-radius: 0 3 3 0, 2, 2;
+    -fx-padding: 0.583333em;
 }
 
 TextField > .right-button:pressed {
@@ -118,14 +115,15 @@ TextField > .right-button:pressed > .right-button-graphic {
     -fx-cursor: default;
 
     -fx-background-radius: 0 3 3 0, 2, 2;
+    -fx-padding: 0.583333em;
 }
 
 .password-field > .right-button > .right-button-graphic {
     -fx-shape: "M307.688,399.564c0,1.484-1.203,2.688-2.688,2.688c-1.484,0-2.688-1.203-2.688-2.688s1.203-2.688,2.688-2.688C306.484,396.876,307.688,398.08,307.688,399.564z M297.5,399h2.5c0,0,1.063-4,5-4c3.688,0,5,4,5,4h2.5c0,0-2.063-6.5-7.5-6.5C299,392.5,297.5,399,297.5,399z";
 
-    -fx-padding: 1em;
-    -fx-scale-shape: false;
+    -fx-padding: 0.416667em;
     -fx-background-color: #111;
+    -fx-scale-shape: false;
 }
 
 .password-field > .right-button:pressed {

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -88,6 +88,10 @@ TextField > .right-button:pressed > .right-button-graphic {
 .password-field {
     -right-button-visible: true;
 
+    -fx-padding: 0.3333333em 0.5833333em 0.3333333em 0.5833333em;
+}
+
+.password-field:focused {
     -fx-padding: 0.3333333em 3em 0.3333333em 0.5833333em;
 }
 

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -64,8 +64,12 @@ TextField:focused {
 TextField > .right-button > .right-button-graphic {
     -fx-shape: "M221.738,305.873l6.135,6.16l-2.875,2.863l-6.135-6.159l-6.263,6.237l-2.864-2.875l6.263-6.238l-6.177-6.202l2.875-2.863l6.177,6.201l6.244-6.22l2.864,2.876L221.738,305.873z";
 
-    -fx-padding: 0.416667em;
+    -fx-padding: 1em;
+    -fx-scale-shape: false;
     -fx-background-color: #111;
+    -fx-scale-x: 0.65;
+    -fx-scale-y: 0.65;
+    -fx-scale-z: 0.65;
 }
 
 TextField > .right-button:hover > .right-button-graphic {
@@ -76,7 +80,6 @@ TextField > .right-button {
     -fx-cursor: default;
 
     -fx-background-radius: 0 3 3 0, 2, 2;
-    -fx-padding: 0 1.0833333em 0 1.0833333em;
 }
 
 TextField > .right-button:pressed {
@@ -115,11 +118,12 @@ TextField > .right-button:pressed > .right-button-graphic {
     -fx-cursor: default;
 
     -fx-background-radius: 0 3 3 0, 2, 2;
-    -fx-padding: 0 1.0833333em 0 1.0833333em;
 }
 
 .password-field > .right-button > .right-button-graphic {
     -fx-shape: "M307.688,399.564c0,1.484-1.203,2.688-2.688,2.688c-1.484,0-2.688-1.203-2.688-2.688s1.203-2.688,2.688-2.688C306.484,396.876,307.688,398.08,307.688,399.564z M297.5,399h2.5c0,0,1.063-4,5-4c3.688,0,5,4,5,4h2.5c0,0-2.063-6.5-7.5-6.5C299,392.5,297.5,399,297.5,399z";
+
+    -fx-padding: 1em;
     -fx-scale-shape: false;
     -fx-background-color: #111;
 }

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -76,7 +76,7 @@ TextField > .right-button {
     -fx-cursor: default;
 
     -fx-background-radius: 0 3 3 0, 2, 2;
-    -fx-padding: 0 1.0833333em 0 1.0833333em
+    -fx-padding: 0 1.0833333em 0 1.0833333em;
 }
 
 TextField > .right-button:pressed {
@@ -115,7 +115,7 @@ TextField > .right-button:pressed > .right-button-graphic {
     -fx-cursor: default;
 
     -fx-background-radius: 0 3 3 0, 2, 2;
-    -fx-padding: 0 1.0833333em 0 1.0833333em
+    -fx-padding: 0 1.0833333em 0 1.0833333em;
 }
 
 .password-field > .right-button > .right-button-graphic {

--- a/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
+++ b/FXSkins/src/main/resources/com/pixelduke/control/skin/fx-skins.css
@@ -68,6 +68,10 @@ TextField > .right-button > .right-button-graphic {
     -fx-background-color: #111;
 }
 
+TextField > .right-button:hover > .right-button-graphic {
+	-fx-background-color: #666666;
+}
+
 TextField > .right-button {
     -fx-cursor: default;
 
@@ -97,6 +101,10 @@ TextField > .right-button:pressed > .right-button-graphic {
     -right-button-visible: true;
 
     -fx-padding: 0.3333333em 0.5833333em 0.3333333em 0.5833333em;
+}
+
+.password-field > .right-button:hover > .right-button-graphic {
+	-fx-background-color: #666666;
 }
 
 .password-field:focused {


### PR DESCRIPTION
Essentially the same changes as https://github.com/JFXtras/jfxtras-styles/pull/195

> Edit: Proposed changes
> 
> 1. Add right padding to Textfield so that text doesn't get under right button
> 2. Have pressed button color be the accent color with the graphic turning white
> 3. Only clear text when mouse released (instead of mouse pressed) -> Unify text clearing interaction with password display interaction

  
  

Focused and unfocused:
![focused1](https://user-images.githubusercontent.com/18708736/115033334-9bd5e200-9eca-11eb-9dca-785ea6c2b83a.png)
![focused2](https://user-images.githubusercontent.com/18708736/115033337-9c6e7880-9eca-11eb-9fae-c37fc5ef72d2.png)

Pressed:
![pressed](https://user-images.githubusercontent.com/18708736/115033338-9c6e7880-9eca-11eb-879a-4a7668ec14ad.png)


Personally i would additionally change the password textfield right button to be visible all the time to hide the padding (see the bottom textfield in figure 1). I would also disable the text selection while holding the password button.