### PR TITLE
Set track event dispatcher to fill to propagate click events for slider

### DIFF
--- a/FXSkins/src/main/java/com/pixelduke/control/skin/FXSliderSkin.java
+++ b/FXSkins/src/main/java/com/pixelduke/control/skin/FXSliderSkin.java
@@ -67,9 +67,9 @@ public class FXSliderSkin extends javafx.scene.control.skin.SliderSkin {
         track.addEventHandler(MouseEvent.MOUSE_PRESSED, this::mousePressedOnTrack);
         track.addEventHandler(MouseEvent.MOUSE_DRAGGED, this::mouseDraggedOnTrack);
         track.addEventHandler(MouseEvent.MOUSE_RELEASED, this::mouseReleasedFromTrack);
-        fill.addEventHandler(MouseEvent.MOUSE_PRESSED, this::mousePressedOnTrack);
-        fill.addEventHandler(MouseEvent.MOUSE_DRAGGED, this::mouseDraggedOnTrack);
-        fill.addEventHandler(MouseEvent.MOUSE_RELEASED, this::mouseReleasedFromTrack);
+        
+        fill.eventDispatcherProperty().bind(track.eventDispatcherProperty());
+        
         thumb.addEventHandler(MouseEvent.MOUSE_PRESSED, this::mousePressedOnThumb);
         thumb.addEventHandler(MouseEvent.MOUSE_DRAGGED, this::mouseDraggedOnThumb);
         thumb.addEventHandler(MouseEvent.MOUSE_RELEASED, this::mouseReleasedFromThumb);


### PR DESCRIPTION
This fixes https://github.com/JFXtras/jfxtras-styles/issues/193 by propagating all the events of the fill down to the track, instead of just calling the same event handler for the popup.

It already incorporates the recommendation by @satsen.

This replaces the PR https://github.com/JFXtras/jfxtras-styles/pull/217.